### PR TITLE
Remove embed visualizers in community resources

### DIFF
--- a/docs/topics/Community_Resources.md
+++ b/docs/topics/Community_Resources.md
@@ -102,12 +102,6 @@ Using Discord's [Dispatch](#DOCS_DISPATCH_DISPATCH_AND_YOU) tool for game develo
 - [ziad87's Intent Calculator](https://ziad87.net/intents/)
 - [Larko's Intent Calculator](https://intents.aymdj.me/)
 
-## Embed Visualizer
-
-Webhooks and embeds might seem like black magic. That's because they are, but let us help you demystify them a bit. This sweet embed visualizer lets you play around with JSON data and see exactly how it will look embedded in Discord. It even includes a webhook mode!
-
-- [LeoV's Embed Visualizer](https://leovoel.github.io/embed-visualizer/)
-
 ## API Types
 
 If you're working on a project that interacts with our API, you might find an API types module useful as it provides type inspection/completion for the Discord API.


### PR DESCRIPTION
This PR removes embed visualizers section in community resources because the only listed visualizer is outdated(last commit was made on 4 years ago) and can cause confusion.